### PR TITLE
fix: update puppet facts and support for RHEL8+

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,7 @@ class bind (
   if $chroot == true {
     $packagenamesuffix = '-chroot'
     # Different service name with chroot on RHEL7+)
-    if $::osfamily == 'RedHat' and
-        versioncmp($::operatingsystemrelease, '7') >= 0 {
+    if $facts['os']['family'] == 'RedHat'
       $servicenamesuffix = '-chroot'
     } else {
       $servicenamesuffix = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 #
 class bind::params {
 
-  case $::osfamily {
+  case $facts['os']['family']{
     'RedHat': {
       $packagenameprefix = 'bind'
       $servicename       = 'named'
@@ -10,29 +10,7 @@ class bind::params {
       $bindgroup         = 'named'
       $file_hint         = 'named.ca'
       $file_rfc1912      = '/etc/named.rfc1912.zones'
-      if versioncmp($::operatingsystemrelease, '8') >= 0 {
-        $file_bindkeys   = '/etc/named.root.key'
-      } else {
-        $file_bindkeys   = '/etc/named.iscdlv.key'
-      }
-    }
-    'Debian': {
-      $packagenameprefix = 'bind9'
-      $servicename       = 'bind9'
-      $binduser          = 'bind'
-      $bindgroup         = 'bind'
-      $file_hint         = '/etc/bind/db.root'
-      $file_rfc1912      = '/etc/bind/named.conf.default-zones'
-      $file_bindkeys     = '/etc/named.iscdlv.key'
-    }
-    'Freebsd': {
-      $packagenameprefix = 'bind910'
-      $servicename       = 'named'
-      $binduser          = 'bind'
-      $bindgroup         = 'bind'
-      $file_hint         = 'named.ca'
-      $file_rfc1912      = '/etc/named.rfc1912.zones'
-      $file_bindkeys     = '/etc/named.iscdlv.key'
+      $file_bindkeys     = '/etc/named.root.key'
     }
     default: {
       $packagenameprefix = 'bind'

--- a/metadata.json
+++ b/metadata.json
@@ -11,25 +11,16 @@
   "operatingsystem_support": [
     {
     "operatingsystem": "RedHat",
-    "operatingsystemrelease": [ "5", "6", "7", "8", "9" ]
-    },
-    {
-    "operatingsystem": "CentOS",
-    "operatingsystemrelease": [ "5", "6", "7", "8", "9" ]
-    },
-    {
-    "operatingsystem": "Debian",
-    "operatingsystemrelease": [ "6", "7", "8" ]
-    },
-    {
-    "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [ "12", "14" ]
+    "operatingsystemrelease": [
+       "8", 
+       "9" 
+     ]
     }
   ],
   "requirements": [
     {
     "name": "puppet",
-    "version_requirement": ">=2.7.20 <8.0.0"
+    "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "dependencies": []


### PR DESCRIPTION
Remove OS support we do not need.

Replace legacy facts with modern facts.